### PR TITLE
feat: Add `openEmpty` for Combobox

### DIFF
--- a/src/components/combobox/combobox.component.ts
+++ b/src/components/combobox/combobox.component.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit/static-html.js';
+import {html} from 'lit/static-html.js';
 import {customElement, property, query, state} from 'lit/decorators.js';
 import SlMenuItem from '../menu-item/menu-item.component.js';
 import SlDropdown from '../dropdown/dropdown.component.js';
@@ -8,8 +8,8 @@ import styles from './combobox.styles.js';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 import {scrollIntoView} from "../../internal/scroll.js";
 import ShoelaceElement from '../../internal/shoelace-element.js';
-import type { SlChangeEvent } from '../../events/sl-change.js';
-import type { SlInputEvent } from '../../events/sl-input.js';
+import type {SlChangeEvent} from '../../events/sl-change.js';
+import type {SlInputEvent} from '../../events/sl-input.js';
 
 export interface Suggestion {
   text: string;
@@ -62,7 +62,7 @@ export default class SlCombobox extends ShoelaceElement {
   @state() suggestions: Array<{ text: string; value: string }> = [];
 
   /** The current input */
-  @property({ type: String }) value = '';
+  @property({type: String}) value = '';
 
   /** The combobox's size. */
   @property({reflect: true}) size: 'small' | 'medium' | 'large' = 'medium';
@@ -100,6 +100,8 @@ export default class SlCombobox extends ShoelaceElement {
   /** The source property is a function executed on user input. The search result is displayed in the suggestions list. */
   @property() source?: SuggestionSource;
 
+  @property() openEmpty: boolean = false;
+
   connectedCallback() {
     super.connectedCallback();
     this.resizeObserver = new ResizeObserver(() => this.resizeMenu());
@@ -115,6 +117,7 @@ export default class SlCombobox extends ShoelaceElement {
     this.input.value = this.value
     this.prepareSuggestions(this.value)
   }
+
   clear() {
     this.input.value = '';
     this.value = '';
@@ -164,9 +167,9 @@ export default class SlCombobox extends ShoelaceElement {
           this.activeItemIndex--;
         }
       }
-        scrollIntoView(menuItems[this.activeItemIndex], this.dropdown.panel);
+      scrollIntoView(menuItems[this.activeItemIndex], this.dropdown.panel);
 
-        return;
+      return;
     }
 
     if (event.key === 'Enter' && this.activeItemIndex !== -1) {
@@ -188,12 +191,16 @@ export default class SlCombobox extends ShoelaceElement {
 
   handleInputFocus = () => {
     if (this.input.value === '') {
+      if (this.openEmpty) {
+        this.prepareSuggestions("");
+        this.dropdown.show();
+      }
       return;
     }
     this.dropdown.show();
   };
 
-  onItemSelected(event: CustomEvent ) {
+  onItemSelected(event: CustomEvent) {
     let item = event.detail.item as SlMenuItem
     this.input.value = item.textContent ?? '';
     this.value = item.textContent ?? '';
@@ -270,7 +277,7 @@ export default class SlCombobox extends ShoelaceElement {
     );
   }
 
-  activeDescendant(): string|null {
+  activeDescendant(): string | null {
     if (this.activeItemIndex === -1) {
       return null;
     }
@@ -298,7 +305,7 @@ export default class SlCombobox extends ShoelaceElement {
           slot="trigger"
           type="text"
           role="combobox"
-          aria-expanded=${this.dropdown? 'true' : 'false'}
+          aria-expanded=${this.dropdown ? 'true' : 'false'}
           size=${this.size}
           label=${this.label}
           placeholder=${this.placeholder}
@@ -341,11 +348,12 @@ export default class SlCombobox extends ShoelaceElement {
               <sl-menu-item disabled>${this.emptyMessage}</sl-menu-item>`
             : this.suggestions.map((item, index) => html`
               <sl-menu-item value=${item.value} id=${this.menuItemId(index)}
-              part="menu-item"
-              exportparts="base:menu-item__base, prefix:menu-item__prefix, suffix:menu-item__suffix, submenu-icon:menu-item__submenu-icon, label:menu-item__label, checked-icon:menu-item__checked-icon"
+                            part="menu-item"
+                            exportparts="base:menu-item__base, prefix:menu-item__prefix, suffix:menu-item__suffix, submenu-icon:menu-item__submenu-icon, label:menu-item__label, checked-icon:menu-item__checked-icon"
 
 
-              >${unsafeHTML(item.text)}</sl-menu-item>`)}
+              >${unsafeHTML(item.text)}
+              </sl-menu-item>`)}
         </sl-menu>
       </sl-dropdown>
     `;

--- a/src/components/combobox/combobox.component.ts
+++ b/src/components/combobox/combobox.component.ts
@@ -99,7 +99,7 @@ export default class SlCombobox extends ShoelaceElement {
 
   /** The source property is a function executed on user input. The search result is displayed in the suggestions list. */
   @property() source?: SuggestionSource;
-
+  /** If true the suggestions are shown even if the Input is empty */
   @property() openEmpty: boolean = false;
 
   connectedCallback() {


### PR DESCRIPTION
If `openEmpty`  is true the suggestions are shown even if the Input is empty