### PR TITLE
fix: Combobox value

### DIFF
--- a/src/components/combobox/combobox.component.ts
+++ b/src/components/combobox/combobox.component.ts
@@ -181,8 +181,8 @@ export default class SlCombobox extends ShoelaceElement {
       event.preventDefault();
       const item = menuItems[this.activeItemIndex];
       if (item) {
-        this.input.value = item.textContent ?? '';
-        this.value = item.textContent ?? '';
+        this.input.value = item.value ?? '';
+        this.value = item.value ?? '';
         this.dropdown.hide();
         //@ts-ignore
         const oldevent = this.emit('sl-item-select', {
@@ -207,8 +207,8 @@ export default class SlCombobox extends ShoelaceElement {
 
   onItemSelected(event: CustomEvent) {
     let item = event.detail.item as SlMenuItem
-    this.input.value = item.textContent ?? '';
-    this.value = item.textContent ?? '';
+    this.input.value = item.value ?? '';
+    this.value = item.value ?? '';
 
 
     //@ts-ignore

--- a/src/components/combobox/combobox.component.ts
+++ b/src/components/combobox/combobox.component.ts
@@ -181,7 +181,7 @@ export default class SlCombobox extends ShoelaceElement {
       event.preventDefault();
       const item = menuItems[this.activeItemIndex];
       if (item) {
-        this.input.value = item.value ?? '';
+        this.input.value = item.textContent.trim() ?? '';
         this.value = item.value ?? '';
         this.dropdown.hide();
         //@ts-ignore
@@ -207,7 +207,7 @@ export default class SlCombobox extends ShoelaceElement {
 
   onItemSelected(event: CustomEvent) {
     let item = event.detail.item as SlMenuItem
-    this.input.value = item.value ?? '';
+    this.input.value = item.textContent.trim() ?? '';
     this.value = item.value ?? '';
 
 


### PR DESCRIPTION
This PR fix the problem that the combobox always has the wrong value.
With text content as the value you have something like this :
`'foo\n              '`
And now we use the actual value from the `sl-select` and it's like this`foo`