### PR TITLE
fix(build): resolve `bootstrap-icons` through node resolution

### DIFF
--- a/scripts/make-icons.js
+++ b/scripts/make-icons.js
@@ -10,6 +10,7 @@ import fm from 'front-matter';
 import fs from 'fs/promises';
 import fso from 'fs';
 import { globby } from 'globby';
+import { createRequire } from 'module';
 import path from 'path';
 import jsdom from 'jsdom';
 const { JSDOM } = jsdom;
@@ -18,7 +19,10 @@ import {optimize} from 'svgo'
 const { outdir } = commandLineArgs({ name: 'outdir', type: String });
 const iconDir = path.join(outdir, '/assets/bootstrap-icons');
 
-const iconPackageData = JSON.parse(await fs.readFile('./node_modules/bootstrap-icons/package.json', 'utf8'));
+// Resolve through Node instead of assuming ./node_modules, so the build also
+// works when the package is installed as a workspace with hoisted dependencies.
+const require = createRequire(import.meta.url);
+const iconPackageData = JSON.parse(await fs.readFile(require.resolve('bootstrap-icons/package.json'), 'utf8'));
 const version = iconPackageData.version;
 const srcPath = `./.cache/icons/icons-${version}`;
 const url = `https://github.com/twbs/icons/archive/v${version}.zip`;


### PR DESCRIPTION
## Summary

- `fix(build)`: resolve `bootstrap-icons` through node resolution instead of a
  cwd-relative `./node_modules` path

## Motivation

`scripts/make-icons.js` read the icon package version from
`./node_modules/bootstrap-icons/package.json`. That path only exists when the
dependency is installed directly inside the package directory.

When this package is consumed as an npm workspace, npm hoists dependencies to
the workspace root, so `bootstrap-icons` lives in the root `node_modules`. The
build then fails at the "Packaging up icons" step:

```
✘ Error: Command failed: node scripts/make-icons.js --outdir "dist"
Error: ENOENT: no such file or directory, open './node_modules/bootstrap-icons/package.json'
```

Because the step aborts, no `dist/` is produced at all. Consumers then hit an
unrelated-looking resolution error, since `package.json` points `exports["."]`
at `./dist/shoelace.js`:

```
✘ [ERROR] Failed to resolve entry for package "@viur/shoelace".
  The package may have incorrect main/module/exports specified in its package.json.
```

`createRequire(import.meta.url).resolve()` uses Node's own lookup, which finds
the package in either location — hoisted or local.

## Verification

Checked in a workspace setup where `bootstrap-icons` is hoisted to the root and
absent from the package's own `node_modules`:

- Before the change, `npm run build` aborted at "Packaging up icons" with the
  `ENOENT` above and left no `dist/`.
- After the change, with `dist/` deleted beforehand, the build reports
  `✔ Packaging up icons` and `✔ Building source files`, and produces both
  `dist/shoelace.js` and `dist/assets/bootstrap-icons/`.
- A downstream Vite project that imports from `@viur/shoelace` then starts
  without the resolution error.

`bootstrap-icons` declares no `exports` field, so `require.resolve()` on its
`package.json` is not subject to export-map restrictions.
